### PR TITLE
feat: generate recursive id

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -6,7 +6,7 @@ const cmdUsage = require('command-line-usage');
 
 const cmdOptionDefinitions = [
     { name: 'ns', type: String },
-    { name: 'name', alias: 'n', type: String, defaultOption: true },
+    { name: 'name', alias: 'n', type: String, multiple: true, defaultOption: true },
     { name: 'verbose', alias: 'v', type: Boolean },
     { name: 'quiet', alias: 'q', type: Boolean },
     { name: 'help', alias: 'h', type: Boolean }
@@ -27,7 +27,7 @@ const cmdOptionSections = [
             {
                 name: 'name',
                 typeLabel: '{underline name}',
-                description: 'The name used to generate the UUID.'
+                description: 'The name used to generate the UUID. Specifying the name argument many times generates the ID recursively.'
             },
             {
                 name: 'verbose',
@@ -102,8 +102,19 @@ const generateScopedId = () => {
     logv(`Namespace: ${namespace}`);
     logv(`Name:      ${name}`);
 
-    return uuid.v5(name, namespace);
+    return generateRecursiveId([...name], namespace);
 };
+
+const generateRecursiveId = (names, namespace) => {
+    if (names.length === 0) {
+        return namespace;
+    }
+
+    const [currentName, ...otherNames] = names;
+    const nextNamespace = uuid.v5(currentName, namespace);
+
+    return generateRecursiveId(otherNames, nextNamespace);
+}
 
 const copyAndPrintId = (id) => {
     try {

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -49,6 +49,17 @@ describe('uuid-cli', () => {
         });
     });
 
+    describe('given multiple names', () => {
+        it('should generate UUID v5 using names recursively', () => {
+            const namespace = uuid.v4();
+            const expectedId = uuid.v5('second', uuid.v5('first', namespace));
+
+            const actual = cli({ quiet: true, ns: namespace, name: ['first', 'second']});
+
+            expect(actual.id).toBe(expectedId);
+        });
+    });
+
     describe('given invalid namespace', () => {
         it('should not throw', () => {
             expect(() => cli({ quiet: true, ns: 'not a UUID', name: 'test' })).not.toThrow();


### PR DESCRIPTION
This PR allows to generate ID using multiple names recursively. It can be called in this on the command-line.

    uuid --name first --name second --name third

An ID is generated using the provided namespace and `first`. The output is used as the next namespace, and so on.