### PR TITLE
fix: wrong branch name in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
This PR fixes the branch name in the release workflow